### PR TITLE
Enable Grayskull-based automatic dependency updates

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+bot:
+  inspection: update-grayskull
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
Enable `bot.inspection: update-grayskull` so the auto-tick bot automatically
updates recipe requirements from PyPI metadata (via
[Grayskull](https://github.com/conda/grayskull)) when creating version bump PRs.

### Motivation

The v2.1.0 version bump PR (#14) had stale dependencies from v2.0.x, a wrong
build backend, and was missing two new deps entirely. This happened because the
bot copies the old recipe and only bumps the version/hash — it doesn't sync
requirements against `pyproject.toml`.

With `update-grayskull`, the bot will read the package metadata from PyPI and
update the `run` requirements automatically, keeping them in sync with
`pyproject.toml`.

### What this changes

Adds two lines to `conda-forge.yml`:

```yaml
bot:
  inspection: update-grayskull
```

No recipe changes, no rerender needed — this only affects bot behavior on
future version bump PRs.
