### PR TITLE
Migrate to v1 recipe format (rattler-build)

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,7 @@
+bot:
+  inspection: update-grayskull
+conda_build_tool: rattler-build
 github:
   branch_name: main
   tooling_branch_name: main
-conda_build:
-  error_overlinking: true
 conda_forge_output_validation: true

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,27 +1,28 @@
-{% set name = "cellrank" %}
-{% set version = "2.1.0" %}
+context:
+  name: cellrank
+  version: "2.1.0"
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: 58a063e1699984355c008e25a91f376f8192d23c84c0c12109cbe27452241b61
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}
     - pip
     - hatchling
     - hatch-vcs
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - anndata >=0.11
     - docrep >=0.3
     - joblib >=1.4
@@ -41,22 +42,22 @@ requirements:
     - session-info2 >=0.2
     - wrapt >=1.16
 
-test:
-  requires:
-    - python {{ python_min }}
-  imports:
-    - cellrank
+tests:
+  - python:
+      imports:
+        - cellrank
+      python_version: ${{ python_min }}
 
 about:
-  home: https://github.com/theislab/cellrank
+  homepage: https://github.com/theislab/cellrank
   license: BSD-3-Clause
   license_file: LICENSE
   summary: Dynamics from multi-view single-cell data
   description: |
     CellRank is a modular framework to study cellular dynamics based on Markov state modeling of
     multi-view single-cell data.
-  doc_url: https://cellrank.readthedocs.io
-  dev_url: https://github.com/theislab/cellrank
+  documentation: https://cellrank.readthedocs.io
+  repository: https://github.com/theislab/cellrank
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Migrate the feedstock from the legacy `meta.yaml` (v0, conda-build) recipe
format to the new `recipe.yaml` (v1, rattler-build) format.

### What changed

**`recipe/meta.yaml` → `recipe/recipe.yaml`**
- `{% set %}` Jinja → `context:` block with `${{ }}` interpolation
- `test:` → `tests:` list with `python:` test type (includes automatic `pip check`)
- `about.home` → `about.homepage`, added `repository` / `documentation` keys
- Removed `conda_build.error_overlinking` (not applicable to rattler-build)
- All deps, version, and sha256 are identical to the merged v2.1.0 recipe

**`conda-forge.yml`**
- Added `conda_build_tool: rattler-build` (switches CI to rattler-build)
- Added `bot.inspection: update-grayskull` (auto-syncs deps from PyPI on
  version bumps — subsumes #15)
- Removed `conda_build.error_overlinking` (conda-build specific)

### Motivation

conda-forge is [migrating to the v1 recipe format](https://conda-forge.org/docs/maintainer/adding_pkgs/#the-recipe-meta-yaml).
The v1 format has cleaner YAML (no Jinja-in-comments selectors), better tooling,
and is the default for new feedstocks. CellRank is a pure Python `noarch`
package — an ideal candidate for this migration.

### Relationship to #15

This PR includes the `bot.inspection: update-grayskull` change from #15. If
this PR is merged first, #15 can be closed. If #15 merges first, this PR will
need a trivial rebase (no conflicts in `recipe/`).
